### PR TITLE
Fix DMA deinit

### DIFF
--- a/Src/ws2812b/ws2812b.c
+++ b/Src/ws2812b/ws2812b.c
@@ -213,11 +213,12 @@ static void DMA2_init(void)
 
 	dmaCC2.Instance = DMA2_Stream2;
 
+	HAL_DMA_DeInit(&dmaCC2);
+
 	dmaCC2.XferCpltCallback  = DMA_TransferCompleteHandler;
 	dmaCC2.XferHalfCpltCallback = DMA_TransferHalfHandler;
 	dmaCC2.XferErrorCallback = DMA_TransferError;
 
-	HAL_DMA_DeInit(&dmaCC2);
 	HAL_DMA_Init(&dmaCC2);
 	HAL_NVIC_SetPriority(DMA2_Stream2_IRQn, 0, 0);
 	HAL_NVIC_EnableIRQ(DMA2_Stream2_IRQn);


### PR DESCRIPTION
DMA DeInit now clears also callbacks

https://github.com/STMicroelectronics/STM32CubeF4/blob/master/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma.c#L355

Fix should be to move callbacks after the DeInit is called.
Please test and let me know. I do not use Windows or Atooliv/STM32IDE anymore.